### PR TITLE
GitHub Actions: Checkout branch instead of SHA

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,8 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -51,6 +53,8 @@ jobs:
       SONATYPE_GPG_KEY_PASSWORD: ${{ secrets.SONATYPE_GPG_KEY_PASSWORD }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
The default behavior breaks `./scripts/publish` as the SHA checkout does not display history with `git log ...`.