### PR TITLE
Update Android Gradle plugin to version 8.7.3

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,7 +15,7 @@ pluginManagement {
 
     plugins {
         kotlin("multiplatform") version "2.1.10"
-        id("com.android.library") version "8.2.2"
+        id("com.android.library") version "8.7.3"
         id("org.jetbrains.dokka") version "2.0.0"
     }
 }


### PR DESCRIPTION
This pull request updates the Android Gradle plugin from version 8.2.2 to 8.7.3 in the project settings. The update ensures compatibility with the latest features and improvements introduced in the newer plugin version.